### PR TITLE
Fix use guard instead of matching on float 0

### DIFF
--- a/src/riak_ql_window_agg_fns.erl
+++ b/src/riak_ql_window_agg_fns.erl
@@ -179,8 +179,7 @@ add(A, B)         -> A + B.
 %%
 divide(?SQL_NULL, _) -> ?SQL_NULL;
 divide(_, ?SQL_NULL) -> ?SQL_NULL;
-divide(_, 0)         -> error(divide_by_zero);
-divide(_, 0.0)       -> error(divide_by_zero);
+divide(_, Value) when Value == 0.0 -> error(divide_by_zero);
 divide(A, B) when is_integer(A) andalso is_integer(B)
                      -> A div B;
 divide(A, B)         -> A / B.


### PR DESCRIPTION
- src/riak_ql_window_agg_fns.erl:183:11: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.